### PR TITLE
🔀 :: Mapper에 toDomain Mapper 추가

### DIFF
--- a/goms-domain/src/main/kotlin/com/goms/v2/domain/auth/RefreshToken.kt
+++ b/goms-domain/src/main/kotlin/com/goms/v2/domain/auth/RefreshToken.kt
@@ -1,12 +1,11 @@
 package com.goms.v2.domain.auth
 
 import com.goms.v2.common.annotation.Aggregate
-import java.time.LocalDateTime
 import java.util.*
 
 @Aggregate
 data class RefreshToken(
     val refreshToken: String,
     val accountIdx: UUID,
-    val expiredAt: LocalDateTime
+    val expiredAt: Int
 )

--- a/goms-domain/src/main/kotlin/com/goms/v2/domain/auth/RefreshToken.kt
+++ b/goms-domain/src/main/kotlin/com/goms/v2/domain/auth/RefreshToken.kt
@@ -1,9 +1,9 @@
 package com.goms.v2.domain.auth
 
-import com.goms.v2.common.annotation.Aggregate
+import com.goms.v2.common.annotation.RootAggregate
 import java.util.*
 
-@Aggregate
+@RootAggregate
 data class RefreshToken(
     val refreshToken: String,
     val accountIdx: UUID,

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/global/event/SaveRefreshTokenEventHandler.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/global/event/SaveRefreshTokenEventHandler.kt
@@ -2,6 +2,7 @@ package com.goms.v2.global.event
 
 import com.goms.v2.domain.auth.RefreshToken
 import com.goms.v2.gloabl.event.SaveRefreshTokenEvent
+import com.goms.v2.global.security.jwt.common.properties.JwtExpTimeProperties
 import com.goms.v2.repository.auth.RefreshTokenRepository
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
@@ -12,7 +13,8 @@ private val log = KotlinLogging.logger {  }
 
 @Component
 class SaveRefreshTokenEventHandler(
-    private val refreshTokenRepository: RefreshTokenRepository
+    private val refreshTokenRepository: RefreshTokenRepository,
+    private val jwtExpTimeProperties: JwtExpTimeProperties
 ) {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -22,7 +24,7 @@ class SaveRefreshTokenEventHandler(
         val refreshToken = RefreshToken(
             refreshToken = saveRefreshTokenEvent.refreshToken,
             accountIdx = saveRefreshTokenEvent.accountIdx,
-            expiredAt = saveRefreshTokenEvent.expiredAt
+            expiredAt = jwtExpTimeProperties.refreshExp
         )
 
         refreshTokenRepository.save(refreshToken)

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/auth/entity/RefreshTokenJpaEntity.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/auth/entity/RefreshTokenJpaEntity.kt
@@ -3,6 +3,7 @@ package com.goms.v2.persistence.auth.entity
 import org.springframework.data.annotation.Id
 import org.springframework.data.redis.core.RedisHash
 import org.springframework.data.redis.core.TimeToLive
+import java.time.LocalDateTime
 import java.util.*
 import java.util.concurrent.TimeUnit
 
@@ -14,5 +15,5 @@ data class RefreshTokenJpaEntity(
     val accountIdx: UUID,
 
     @TimeToLive(unit = TimeUnit.SECONDS)
-    val expiredAt: Int
+    val expiredAt: LocalDateTime
 )

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/auth/entity/RefreshTokenJpaEntity.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/auth/entity/RefreshTokenJpaEntity.kt
@@ -3,7 +3,6 @@ package com.goms.v2.persistence.auth.entity
 import org.springframework.data.annotation.Id
 import org.springframework.data.redis.core.RedisHash
 import org.springframework.data.redis.core.TimeToLive
-import java.time.LocalDateTime
 import java.util.*
 import java.util.concurrent.TimeUnit
 
@@ -15,5 +14,5 @@ data class RefreshTokenJpaEntity(
     val accountIdx: UUID,
 
     @TimeToLive(unit = TimeUnit.SECONDS)
-    val expiredAt: LocalDateTime
+    val expiredAt: Int
 )

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/auth/mapper/RefreshTokenMapper.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/auth/mapper/RefreshTokenMapper.kt
@@ -12,5 +12,6 @@ import org.mapstruct.*
 interface RefreshTokenMapper {
 
     fun toEntity(refreshToken: RefreshToken): RefreshTokenJpaEntity
+    fun toDomain(refreshTokenJpaEntity: RefreshTokenJpaEntity): RefreshToken
 
 }


### PR DESCRIPTION
## 💡 개요
+ RefreshTokenMapper에 대한 RefreshTokenMapperImpl 클래스에서 에러가 발생해서 삭제를 했는데 다시 생기지 않는 이슈가 발생했습니다.

+ RefreshTokenMapperImpl 클래스를 다시 생성되는 과정에서 RefreshToken과 RefreshTokenJpaEntity의 expiredAt 타입이 달라서 RefreshTokenMapperImpl가 생기지 않습니다.
## 📃 작업사항
+ RefreshTokenJpaEntity와 RefreshToken의 expiredAt의 타입을 Int로 통일하였습니다.
## 🙋‍♂️ 리뷰내용