### PR TITLE
🔀 :: GAuth 로그인 에러 고치기

### DIFF
--- a/goms-application/src/main/kotlin/com/goms/v2/domain/auth/data/dto/GAuthUserInfoDto.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/auth/data/dto/GAuthUserInfoDto.kt
@@ -6,5 +6,5 @@ data class GAuthUserInfoDto(
     val grade: Int,
     val classNum: Int,
     val num: Int,
-    val profileUrl: String
+    val profileUrl: String?
 )

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/thirdparty/gauth/GAuthAdapter.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/thirdparty/gauth/GAuthAdapter.kt
@@ -9,7 +9,7 @@ import com.goms.v2.domain.auth.exception.GAuthServiceNotFoundException
 import com.goms.v2.domain.auth.spi.GAuthPort
 import com.goms.v2.gloabl.exception.exception.GomsException
 import com.goms.v2.thirdparty.gauth.property.GAuthProperties
-import com.goms.v2.persistence.auth.mapper.GAuthDataMapper
+import com.goms.v2.thirdparty.gauth.mapper.GAuthDataMapper
 import gauth.GAuth
 import gauth.exception.GAuthException
 import org.springframework.stereotype.Component

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/thirdparty/gauth/mapper/GAuthDataMapper.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/thirdparty/gauth/mapper/GAuthDataMapper.kt
@@ -1,4 +1,4 @@
-package com.goms.v2.persistence.auth.mapper
+package com.goms.v2.thirdparty.gauth.mapper
 
 import com.goms.v2.domain.auth.data.dto.GAuthTokenDto
 import com.goms.v2.domain.auth.data.dto.GAuthUserInfoDto


### PR DESCRIPTION
## 💡 개요
- GAuth 로그인이 `프로필URL`이 null인 사람은 로그인인 안되는 에러가 발생했습니다.
## 📃 작업사항
- GAuth에 정보를 받아오는 dto에서 `프로필URL` 에 `?`를 붙여서 null인 정보도 dto에 저장할 수 있도록 수정하였습니다.
- 패키지를 이동시켰습니다.
## 🙋‍♂️ 리뷰내용