### PR TITLE
🔀 :: 마리아 DB 의존성 추가

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -26,6 +26,7 @@ object Dependencies {
     const val MYSQL_CONNECTOR = "com.mysql:mysql-connector-j"
     const val SPRING_REDIS = "org.springframework.boot:spring-boot-starter-data-redis"
     const val REDIS = "org.springframework.data:spring-data-redis:${DependenciesVersions.REDIS_VERSION}"
+    const val MARIA_DB = "org.mariadb.jdbc:mariadb-java-client:${DependenciesVersions.MARIA_DB_VERSION}"
 
     /* queryDsl */
     const val QUERYDSL = "com.querydsl:querydsl-jpa:${DependenciesVersions.QUERYDSL}"

--- a/buildSrc/src/main/kotlin/DependenciesVersions.kt
+++ b/buildSrc/src/main/kotlin/DependenciesVersions.kt
@@ -9,6 +9,7 @@ object DependenciesVersions {
     const val SERVLET_VERSION = "4.0.1"
     const val EMAIL = "2.6.7"
     const val REDIS_VERSION = "2.7.2"
+    const val MARIA_DB_VERSION = "2.1.2"
     const val JWT_VERSION = "0.11.5"
     const val MAP_STRUCT_VERSION = "1.5.2.Final"
     const val GAUTH_VERSION = "v2.0.0"

--- a/goms-infrastructure/build.gradle.kts
+++ b/goms-infrastructure/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     runtimeOnly(Dependencies.MYSQL_CONNECTOR)
     implementation(Dependencies.REDIS)
     implementation(Dependencies.SPRING_REDIS)
+    implementation(Dependencies.MARIA_DB)
 
     /* mapstruct */
     implementation(Dependencies.MAP_STRUCT)


### PR DESCRIPTION
## 💡 개요
- 클라우드 타입 배포를 위한 마리아 DB 의존성을 추가하였습니다.
## 📃 작업사항
- infra 모듈에 마리아 DB 의존성을 추가하였습니다.
## 🙋‍♂️ 리뷰내용