### PR TITLE
MethodArgumentNotValidException 핸들러 수정

### DIFF
--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/global/exception/handler/GlobalExceptionHandler.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/global/exception/handler/GlobalExceptionHandler.kt
@@ -21,8 +21,8 @@ class GlobalExceptionHandler {
 	@ExceptionHandler(MethodArgumentNotValidException::class)
 	fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> =
 		ResponseEntity(
-			ErrorResponse(e.message, HttpStatus.BAD_REQUEST.value()),
-			HttpStatus.valueOf(e.hashCode())
+			ErrorResponse(e.bindingResult.fieldError?.defaultMessage, HttpStatus.BAD_REQUEST.value()),
+			HttpStatus.valueOf(HttpStatus.BAD_REQUEST.value())
 		)
 
 }

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/global/exception/handler/GlobalExceptionHandler.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/global/exception/handler/GlobalExceptionHandler.kt
@@ -4,6 +4,7 @@ import com.goms.v2.common.exception.GomsException
 import com.goms.v2.global.exception.response.ErrorResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -22,6 +23,13 @@ class GlobalExceptionHandler {
 	fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> =
 		ResponseEntity(
 			ErrorResponse(e.bindingResult.fieldError?.defaultMessage, HttpStatus.BAD_REQUEST.value()),
+			HttpStatus.valueOf(HttpStatus.BAD_REQUEST.value())
+		)
+
+	@ExceptionHandler(HttpMessageNotReadableException::class)
+	fun handleHttpMessageNotReadableException(e: HttpMessageNotReadableException): ResponseEntity<ErrorResponse> =
+		ResponseEntity(
+			ErrorResponse("json 형식이 잘못되었습니다.", HttpStatus.BAD_REQUEST.value()),
 			HttpStatus.valueOf(HttpStatus.BAD_REQUEST.value())
 		)
 


### PR DESCRIPTION
## 💡 개요
+ MethodArgumentNotValidException 핸들러가 되지않아 수정 하였습니다.
## 📃 작업사항
+ MethodArgumentNotValidException 핸들러의 ErrorResponse message 값을 수정하였습니다.
+ HttpMessageNotReadableException 핸들러를 추가하였습니다.
## 🙋‍♂️ 리뷰내용