### PR TITLE
🔀 :: 메서드 반환 타입에 변경에 따른 테스트코드 수정

### DIFF
--- a/goms-application/src/main/kotlin/com/goms/v2/domain/auth/usecase/SignInUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/auth/usecase/SignInUseCase.kt
@@ -57,8 +57,7 @@ class SignInUseCase(
             authority = Authority.ROLE_STUDENT,
             createdTime = LocalDateTime.now()
         )
-        accountRepository.save(account)
-        return account
+        return accountRepository.save(account)
     }
 
     private fun publishSaveRefreshToken(token: TokenDto, account: Account) {

--- a/goms-application/src/test/kotlin/com/goms/v2/domain/studentCouncil/GrantAuthorityUseCaseTest.kt
+++ b/goms-application/src/test/kotlin/com/goms/v2/domain/studentCouncil/GrantAuthorityUseCaseTest.kt
@@ -24,7 +24,7 @@ class GrantAuthorityUseCaseTest: BehaviorSpec({
         val account = AnyValueObjectGenerator.anyValueObject<Account>("idx" to accountIdx)
 
         every { accountRepository.findByIdOrNull(account.idx) } returns account
-        every { accountRepository.save(any()) } returns Unit
+        every { accountRepository.save(any()) } returns account
 
         When("권한 수정 요청을 하면") {
             grantAuthorityUseCase.execute(grantAuthorityDto)

--- a/goms-domain/src/main/kotlin/com/goms/v2/repository/account/AccountRepository.kt
+++ b/goms-domain/src/main/kotlin/com/goms/v2/repository/account/AccountRepository.kt
@@ -5,7 +5,7 @@ import java.util.UUID
 
 interface AccountRepository {
 
-    fun save(account: Account)
+    fun save(account: Account): Account
     fun findByIdOrNull(accountIdx: UUID): Account?
     fun findByEmail(email: String): Account?
     fun existsByEmail(email: String): Boolean

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/account/repository/AccountRepositoryImpl.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/account/repository/AccountRepositoryImpl.kt
@@ -16,9 +16,10 @@ class AccountRepositoryImpl(
     private val queryFactory: JPAQueryFactory
 ): AccountRepository {
 
-    override fun save(account: Account) {
+    override fun save(account: Account): Account {
         val accountEntity = accountMapper.toEntity(account)
         accountJpaRepository.save(accountEntity)
+        return account
     }
 
     override fun findByIdOrNull(accountIdx: UUID) =


### PR DESCRIPTION
## 💡 개요
- save() 메서드에 대한 반환타입을 만들었습니다.
- 예전에는 `save()`메서드에 대한 반환타입이 없었습니다.
- 로그인 테스트코드를 작성하는 과정에서 `save()`메서드의 반환값이 필요해서 `Account` 객체의 반환값을 추가하였습니다.
- `save()`에서 `Account`를 반환하게 수정을 하면 기존의 `GrantAuthorityUseCaseTest` 테스트코드에서 `Unit`으로 반환해야하는 걸 `Account`객체의 타입으로 반환하도록 수정해야하는데 제가 `GrantAuthorityUseCaseTest`에서 `Account`객체로 변경하지 않아서 ci 검사도중 테스토코드 에러가 발생하였습니다.
## 📃 작업사항
- `save()` 메서드에 대한 반환타입을 `Account`로 지정하였습니다.
- 테스트코드에서 `save()` 메서드를 사용할때 `Account`객체를 반환하게 수정하였습니다.
## 🙋‍♂️ 리뷰내용
- 잘못된 컨벤션이 있는지 확인해주세요.
- 또 다른 컨플릭트가 날 만한 로직이 있는지 확인해주세요.