### PR TITLE
🔀 :: TokenParsePort로 클래스명 변경

### DIFF
--- a/goms-application/src/main/kotlin/com/goms/v2/domain/auth/spi/TokenParsePort.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/auth/spi/TokenParsePort.kt
@@ -1,7 +1,7 @@
 package com.goms.v2.domain.auth.spi
 
 
-interface TokenParserPort {
+interface TokenParsePort {
 
     fun parseRefreshToken(refreshToken: String): String?
 

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/auth/usecase/ReissueTokenUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/auth/usecase/ReissueTokenUseCase.kt
@@ -7,7 +7,7 @@ import com.goms.v2.domain.auth.data.dto.TokenDto
 import com.goms.v2.domain.auth.exception.AccountNotFoundException
 import com.goms.v2.domain.auth.exception.ExpiredRefreshTokenException
 import com.goms.v2.domain.auth.exception.InvalidTokenTypeException
-import com.goms.v2.domain.auth.spi.TokenParserPort
+import com.goms.v2.domain.auth.spi.TokenParsePort
 import com.goms.v2.domain.auth.spi.TokenPort
 import com.goms.v2.repository.account.AccountRepository
 import com.goms.v2.repository.auth.RefreshTokenRepository
@@ -17,11 +17,11 @@ class ReissueTokenUseCase(
     private val refreshTokenRepository: RefreshTokenRepository,
     private val accountRepository: AccountRepository,
     private val tokenPort: TokenPort,
-    private val tokenParserPort: TokenParserPort
+    private val tokenParsePort: TokenParsePort
 ) {
 
     fun execute(refreshToken: String): TokenDto {
-        val parsedRefreshToken = tokenParserPort.parseRefreshToken(refreshToken) ?: throw InvalidTokenTypeException()
+        val parsedRefreshToken = tokenParsePort.parseRefreshToken(refreshToken) ?: throw InvalidTokenTypeException()
         val refreshTokenDomain = refreshTokenRepository.findByIdOrNull(parsedRefreshToken) ?: throw ExpiredRefreshTokenException()
         val account = accountRepository.findByIdOrNull(refreshTokenDomain.accountIdx) ?: throw AccountNotFoundException()
         val token = tokenPort.generateToken(refreshTokenDomain.accountIdx, account.authority)

--- a/goms-application/src/test/kotlin/com/goms/v2/domain/auth/ReissueTokenUseCaseTest.kt
+++ b/goms-application/src/test/kotlin/com/goms/v2/domain/auth/ReissueTokenUseCaseTest.kt
@@ -6,7 +6,7 @@ import com.goms.v2.domain.auth.data.dto.TokenDto
 import com.goms.v2.domain.auth.exception.AccountNotFoundException
 import com.goms.v2.domain.auth.exception.ExpiredRefreshTokenException
 import com.goms.v2.domain.auth.exception.InvalidTokenTypeException
-import com.goms.v2.domain.auth.spi.TokenParserPort
+import com.goms.v2.domain.auth.spi.TokenParsePort
 import com.goms.v2.domain.auth.spi.TokenPort
 import com.goms.v2.domain.auth.usecase.ReissueTokenUseCase
 import com.goms.v2.repository.account.AccountRepository
@@ -22,8 +22,8 @@ class ReissueTokenUseCaseTest: BehaviorSpec({
     val refreshTokenRepository = mockk<RefreshTokenRepository>()
     val accountRepository = mockk<AccountRepository>()
     val tokenPort = mockk<TokenPort>()
-    val tokenParserPort = mockk<TokenParserPort>()
-    val reissueTokenUseCase = ReissueTokenUseCase(refreshTokenRepository, accountRepository, tokenPort, tokenParserPort)
+    val tokenParsePort = mockk<TokenParsePort>()
+    val reissueTokenUseCase = ReissueTokenUseCase(refreshTokenRepository, accountRepository, tokenPort, tokenParsePort)
 
     Given("refreshToken이 주어졌을때") {
         val refreshToken = "Bearer test refreshToken"
@@ -32,7 +32,7 @@ class ReissueTokenUseCaseTest: BehaviorSpec({
         val refreshTokenDomain = AnyValueObjectGenerator.anyValueObject<RefreshToken>("refreshToken" to parsedRefreshToken)
         val account = AnyValueObjectGenerator.anyValueObject<Account>("idx" to refreshTokenDomain.accountIdx)
 
-        every { tokenParserPort.parseRefreshToken(refreshToken) } returns parsedRefreshToken
+        every { tokenParsePort.parseRefreshToken(refreshToken) } returns parsedRefreshToken
         every { refreshTokenRepository.findByIdOrNull(parsedRefreshToken) } returns refreshTokenDomain
         every { accountRepository.findByIdOrNull(refreshTokenDomain.accountIdx) } returns account
         every { tokenPort.generateToken(refreshTokenDomain.accountIdx, account.authority) } returns tokenDto
@@ -56,7 +56,7 @@ class ReissueTokenUseCaseTest: BehaviorSpec({
         }
 
         When("유효하지 않는 토큰 타입으로 요청하면") {
-            every { tokenParserPort.parseRefreshToken(refreshToken) } returns null
+            every { tokenParsePort.parseRefreshToken(refreshToken) } returns null
 
             Then("InvalidTokenTypeException이 터저야 한다.") {
                 shouldThrow<InvalidTokenTypeException> {
@@ -66,7 +66,7 @@ class ReissueTokenUseCaseTest: BehaviorSpec({
         }
 
         When("만료된 토큰으로 요청하면") {
-            every { tokenParserPort.parseRefreshToken(refreshToken) } returns parsedRefreshToken
+            every { tokenParsePort.parseRefreshToken(refreshToken) } returns parsedRefreshToken
             every { refreshTokenRepository.findByIdOrNull(parsedRefreshToken) } returns null
 
             Then("ExpiredRefreshTokenException이 터져야 한다.") {
@@ -77,7 +77,7 @@ class ReissueTokenUseCaseTest: BehaviorSpec({
         }
 
         When("계정을 찾을 수 없으면") {
-            every { tokenParserPort.parseRefreshToken(refreshToken) } returns parsedRefreshToken
+            every { tokenParsePort.parseRefreshToken(refreshToken) } returns parsedRefreshToken
             every { refreshTokenRepository.findByIdOrNull(parsedRefreshToken) } returns refreshTokenDomain
             every { accountRepository.findByIdOrNull(refreshTokenDomain.accountIdx) } returns null
 

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/global/security/jwt/TokenParserAdapter.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/global/security/jwt/TokenParserAdapter.kt
@@ -1,12 +1,12 @@
 package com.goms.v2.global.security.jwt
 
-import com.goms.v2.domain.auth.spi.TokenParserPort
+import com.goms.v2.domain.auth.spi.TokenParsePort
 import org.springframework.stereotype.Component
 
 @Component
-class TokenParserAdapter(
+class TokenParseAdapter(
     private val jwtParser: JwtParser
-): TokenParserPort{
+): TokenParsePort {
 
     override fun parseRefreshToken(refreshToken: String): String? =
         jwtParser.parseRefreshToken(refreshToken)


### PR DESCRIPTION
## 💡 개요
- 클래스명을 변경하였습니다.
## 📃 작업사항
- 기존의 TokenParserPort를 TokenParsePort로 변경하였습니다.
## 🙋‍♂️ 리뷰내용
- 클래스명이 바뀌지 않은 곳이 있는지 확인해주세요.