### PR TITLE
🔀 :: 이메일 전송하기 전에 GOMS 회원인지 검증하기

### DIFF
--- a/goms-application/src/main/kotlin/com/goms/v2/domain/auth/usecase/SendEmailUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/auth/usecase/SendEmailUseCase.kt
@@ -20,9 +20,10 @@ class SendEmailUseCase(
 ) {
 
     fun execute(emailDto: EmailDto) {
-        val isExistsAuthentication = authenticationRepository.existByEmail(emailDto.email)
-        if (isExistsAuthentication) saveAuthentication(emailDto.email)
-        if (!isExistsAuthentication) createAuthentication(emailDto.email)
+        val account = accountRepository.findByEmail(emailDto.email) ?: throw AccountNotFoundException()
+        val isExistsAuthentication = authenticationRepository.existByEmail(account.email)
+        if (isExistsAuthentication) saveAuthentication(account.email)
+        if (!isExistsAuthentication) createAuthentication(account.email)
         val authCode = generateAuthKey(9999)
         saveAuthCode(emailDto, authCode)
         emailSendPort.sendEmail(emailDto.email, authCode)


### PR DESCRIPTION
## 💡 개요
- 이메일 로그인은 GOMS 회원인 사용자만 가능하기 때문에 이메일 전송 전에 회원검증을 해야합니다.
## 📃 작업사항
- 이메일 로그인을 위한 이메일 전송 전에 회원검증 로직을 추가하였습니다.
## 🙋‍♂️ 리뷰내용
- 컨벤션에 맞지 않은 부분이 있는지 확인해주세요.