### PR TITLE
🔀 :: 지각자 저장 시간 변경

### DIFF
--- a/goms-application/src/main/kotlin/com/goms/v2/domain/outing/scheduler/OutingScheduler.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/outing/scheduler/OutingScheduler.kt
@@ -11,7 +11,7 @@ class OutingScheduler(
     private val deleteOutingStudentsUseCase: DeleteOutingStudentsUseCase,
 ) {
 
-    @Scheduled(cron = "0 25 19 ? * 3") // 매주 수요일 7시 25분에 지각자를 저장한다.
+    @Scheduled(cron = "0 26 19 ? * 3") // 매주 수요일 7시 26분에 지각자를 저장한다.
     fun checkRateStudent() = saveLateAccountUseCase.execute()
 
     @Scheduled(cron = "0 50 19 ? * 3") // 매주 수요일 7시 50분에 외출자를 삭제한다.


### PR DESCRIPTION
## 💡 개요
- 7시25분까지 외출시간이어서 25분에 지각자가 저장이 되면 안됩니다.
- 7시26분에 지각자가 저장이 되야 합니다.
## 📃 작업사항
- 지각자를 저장하는 시간을 7시25분에서 7시26분으로 변경하였습니다.
## 🙋‍♂️ 리뷰내용