### PR TITLE
🔀 :: 회원가입 이메일 인증 로직 추가

### DIFF
--- a/goms-application/src/main/kotlin/com/goms/v2/common/exception/ErrorCode.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/common/exception/ErrorCode.kt
@@ -26,7 +26,7 @@ enum class ErrorCode(
 	PASSWORD_NOT_MATCH("일치하지 않는 비밀번호입니다.", ErrorStatus.BAD_REQUEST),
 
 	// AUTHENTICATION
-	AUTHENTICATION_NOT_FOUND("인증되지 않은 사용자 입니다.", ErrorStatus.NOT_FOUND),
+	AUTHENTICATION_NOT_FOUND("인증되지 않은 사용자 입니다.", ErrorStatus.UNAUTHORIZED),
 
 	// ACCOUNT
 	ACCOUNT_NOT_FOUND("계정을 찾을 수 없습니다.", ErrorStatus.NOT_FOUND),

--- a/goms-application/src/main/kotlin/com/goms/v2/common/util/AuthenticationValidator.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/common/util/AuthenticationValidator.kt
@@ -1,0 +1,21 @@
+package com.goms.v2.common.util
+
+import com.goms.v2.common.annotation.UseCaseWithTransaction
+import com.goms.v2.domain.auth.Authentication
+import com.goms.v2.domain.auth.exception.AuthenticationNotFoundException
+import com.goms.v2.repository.auth.AuthenticationRepository
+
+@UseCaseWithTransaction
+class AuthenticationValidator(
+    private val authenticationRepository: AuthenticationRepository,
+) {
+
+    fun verifyAuthenticationByEmail(email: String): Authentication {
+        val authentication = authenticationRepository.findByIdOrNull(email)
+            ?: throw AuthenticationNotFoundException()
+        if (!authentication.isAuthentication)
+            throw AuthenticationNotFoundException()
+        return authentication
+    }
+
+}

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/auth/data/event/DeleteAuthenticationEvent.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/auth/data/event/DeleteAuthenticationEvent.kt
@@ -1,0 +1,7 @@
+package com.goms.v2.domain.auth.data.event
+
+import com.goms.v2.domain.auth.Authentication
+
+data class DeleteAuthenticationEvent(
+    val authentication: Authentication
+)

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/auth/data/event/DeleteAuthenticationEventHandler.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/auth/data/event/DeleteAuthenticationEventHandler.kt
@@ -1,0 +1,20 @@
+package com.goms.v2.domain.auth.data.event
+
+import com.goms.v2.repository.auth.AuthenticationRepository
+import mu.KotlinLogging
+import org.springframework.context.event.EventListener
+
+private val log = KotlinLogging.logger {}
+
+class DeleteAuthenticationEventHandler(
+    private val authenticationRepository: AuthenticationRepository
+) {
+
+    @EventListener
+    fun deleteAuthentication(createAuthenticationEvent: CreateAuthenticationEvent) {
+        log.info("deleteAuthenticationEvent is active")
+
+        authenticationRepository.delete(createAuthenticationEvent.authentication)
+    }
+
+}

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/auth/usecase/SignUpUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/auth/usecase/SignUpUseCase.kt
@@ -1,24 +1,33 @@
 package com.goms.v2.domain.auth.usecase
 
 import com.goms.v2.common.annotation.UseCaseWithTransaction
+import com.goms.v2.common.util.AuthenticationValidator
 import com.goms.v2.domain.account.Account
 import com.goms.v2.domain.account.constant.Authority
 import com.goms.v2.domain.auth.data.dto.SignUpDto
+import com.goms.v2.domain.auth.data.event.DeleteAuthenticationEvent
 import com.goms.v2.domain.auth.exception.AlreadyExistEmailException
 import com.goms.v2.domain.auth.spi.PasswordEncoderPort
 import com.goms.v2.repository.account.AccountRepository
+import org.springframework.context.ApplicationEventPublisher
 import java.time.LocalDateTime
 import java.util.*
 
 @UseCaseWithTransaction
 class SignUpUseCase(
     private val accountRepository: AccountRepository,
-    private val passwordEncoderPort: PasswordEncoderPort
+    private val passwordEncoderPort: PasswordEncoderPort,
+    private val authenticationValidator: AuthenticationValidator,
+    private val publisher: ApplicationEventPublisher
 ) {
 
     fun execute(signUpDto: SignUpDto) {
         if (accountRepository.existsByEmail(signUpDto.email))
             throw AlreadyExistEmailException()
+
+        val authentication = authenticationValidator.verifyAuthenticationByEmail(signUpDto.email)
+        val deleteAuthenticationEvent = DeleteAuthenticationEvent(authentication)
+        publisher.publishEvent(deleteAuthenticationEvent)
 
         val account = Account(
             idx = UUID.randomUUID(),

--- a/goms-domain/src/main/kotlin/com/goms/v2/repository/auth/AuthenticationRepository.kt
+++ b/goms-domain/src/main/kotlin/com/goms/v2/repository/auth/AuthenticationRepository.kt
@@ -5,6 +5,7 @@ import com.goms.v2.domain.auth.Authentication
 interface AuthenticationRepository {
 
     fun save(authentication: Authentication)
+    fun delete(authentication: Authentication)
     fun existByEmail(email: String): Boolean
     fun findByIdOrNull(email: String): Authentication?
 

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/auth/repository/AuthenticationRepositoryImpl.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/auth/repository/AuthenticationRepositoryImpl.kt
@@ -13,8 +13,13 @@ class AuthenticationRepositoryImpl(
 ): AuthenticationRepository {
 
     override fun save(authentication: Authentication) {
-        val authCodeEntity = authenticationMapper.toEntity(authentication)
-        authenticationRedisRepository.save(authCodeEntity)
+        val authenticationEntity = authenticationMapper.toEntity(authentication)
+        authenticationRedisRepository.save(authenticationEntity)
+    }
+
+    override fun delete(authentication: Authentication) {
+        val authenticationEntity = authenticationMapper.toEntity(authentication)
+        authenticationRedisRepository.delete(authenticationEntity)
     }
 
     override fun existByEmail(email: String): Boolean {


### PR DESCRIPTION
## 💡 개요
+ 회원가입 시 이메일 인증을 한 사용자 인지 구분하는 검증 로직을 추가하였습니다.
## 📃 작업사항
+ 회원가입을 할때 이메일 인증에 성공해서 Authentication 객체가 생성되었는지 확인하는 로직을 추가하였습니다.
+ 인증된 사용자인지 확인이 되고 회원가입이 마무리 되면 Authentication 객체를 삭제하는 Spring Event를 추가하였습니다.
+ 인증되지 않은 사용자일때 발생되는 예외처리의 상태코드를 변경하였습니다.
   + 404 -> 401

## 🙋‍♂️ 리뷰내용