### PR TITLE
🔀 :: 비밀번호 재설정 API

### DIFF
--- a/goms-application/src/main/kotlin/com/goms/v2/common/exception/ErrorCode.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/common/exception/ErrorCode.kt
@@ -24,6 +24,7 @@ enum class ErrorCode(
 	// AUTH
 	ALREADY_EXIST_EMAIL("이미 존재하는 이메일입니다.", ErrorStatus.CONFLICT),
 	PASSWORD_NOT_MATCH("일치하지 않는 비밀번호입니다.", ErrorStatus.BAD_REQUEST),
+	DUPLICATE_NEW_PASSWORD("이미 사용중인 비밀번호입니다.", ErrorStatus.BAD_REQUEST),
 
 	// AUTHENTICATION
 	AUTHENTICATION_NOT_FOUND("인증되지 않은 사용자 입니다.", ErrorStatus.UNAUTHORIZED),

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/account/data/dto/PasswordDto.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/account/data/dto/PasswordDto.kt
@@ -1,0 +1,6 @@
+package com.goms.v2.domain.account.data.dto
+
+data class PasswordDto(
+    val email: String,
+    val newPassword: String
+)

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/account/exception/DuplicatedNewPasswordException.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/account/exception/DuplicatedNewPasswordException.kt
@@ -1,0 +1,6 @@
+package com.goms.v2.domain.account.exception
+
+import com.goms.v2.common.exception.ErrorCode
+import com.goms.v2.common.exception.GomsException
+
+class DuplicatedNewPasswordException: GomsException(ErrorCode.DUPLICATE_NEW_PASSWORD)

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/account/usecase/UpdatePasswordUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/account/usecase/UpdatePasswordUseCase.kt
@@ -1,0 +1,37 @@
+package com.goms.v2.domain.account.usecase
+
+import com.goms.v2.common.annotation.UseCaseWithTransaction
+import com.goms.v2.common.util.AuthenticationValidator
+import com.goms.v2.domain.account.data.dto.PasswordDto
+import com.goms.v2.domain.account.exception.DuplicatedNewPasswordException
+import com.goms.v2.domain.account.updatePassword
+import com.goms.v2.domain.auth.data.event.DeleteAuthenticationEvent
+import com.goms.v2.domain.auth.exception.AccountNotFoundException
+import com.goms.v2.domain.auth.spi.PasswordEncoderPort
+import com.goms.v2.repository.account.AccountRepository
+import org.springframework.context.ApplicationEventPublisher
+
+@UseCaseWithTransaction
+class UpdatePasswordUseCase(
+    private val accountRepository: AccountRepository,
+    private val authenticationValidator: AuthenticationValidator,
+    private val passwordEncoderPort: PasswordEncoderPort,
+    private val publisher: ApplicationEventPublisher
+) {
+
+    fun execute(passwordDto: PasswordDto) {
+        val account = accountRepository.findByEmail(passwordDto.email)
+            ?: throw AccountNotFoundException()
+
+        if (passwordEncoderPort.isPasswordMatch(passwordDto.newPassword, account.password)) {
+            throw DuplicatedNewPasswordException()
+        }
+
+        val authentication = authenticationValidator.verifyAuthenticationByEmail(passwordDto.email)
+        publisher.publishEvent(DeleteAuthenticationEvent(authentication))
+
+        account.updatePassword(passwordEncoderPort.passwordEncode(passwordDto.newPassword))
+        accountRepository.save(account)
+    }
+
+}

--- a/goms-domain/src/main/kotlin/com/goms/v2/domain/account/Account.kt
+++ b/goms-domain/src/main/kotlin/com/goms/v2/domain/account/Account.kt
@@ -11,7 +11,7 @@ import java.util.*
 data class Account(
     val idx: UUID,
     val email: String,
-    val password: String,
+    var password: String,
     val grade: Int,
     val gender: Gender,
     val major: Major,
@@ -23,4 +23,8 @@ data class Account(
 
 fun Account.updateAuthority(newAuthority: Authority) {
     authority = newAuthority
+}
+
+fun Account.updatePassword(newPassword: String) {
+    password = newPassword
 }

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/account/entity/AccountJpaEntity.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/account/entity/AccountJpaEntity.kt
@@ -18,7 +18,7 @@ class AccountJpaEntity(
     val email: String,
 
     @Column(nullable = false)
-    val password: String,
+    var password: String,
 
     @Column(nullable = false)
     val grade: Int,

--- a/goms-presentation/src/main/kotlin/com/goms/v2/domain/account/AccountController.kt
+++ b/goms-presentation/src/main/kotlin/com/goms/v2/domain/account/AccountController.kt
@@ -1,10 +1,15 @@
 package com.goms.v2.domain.account
 
+import com.goms.v2.domain.account.dto.request.UpdatePasswordRequest
 import com.goms.v2.domain.account.dto.response.ProfileHttpResponse
 import com.goms.v2.domain.account.mapper.AccountDataMapper
 import com.goms.v2.domain.account.usecase.QueryAccountProfileUseCase
+import com.goms.v2.domain.account.usecase.UpdatePasswordUseCase
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -13,12 +18,18 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("api/v2/account")
 class AccountController(
     private val accountDataMapper: AccountDataMapper,
-    private val queryAccountProfileUseCase: QueryAccountProfileUseCase
+    private val queryAccountProfileUseCase: QueryAccountProfileUseCase,
+    private val updatePasswordUseCase: UpdatePasswordUseCase
 ) {
 
     @GetMapping("profile")
     fun queryProfile(): ResponseEntity<ProfileHttpResponse> =
         queryAccountProfileUseCase.execute()
             .let { ResponseEntity.ok(accountDataMapper.toResponse(it)) }
+
+    @PatchMapping("new-password")
+    fun updatePassword(@RequestBody updatePasswordRequest: UpdatePasswordRequest): ResponseEntity<Void> =
+        updatePasswordUseCase.execute(accountDataMapper.toDomain(updatePasswordRequest))
+            .let { ResponseEntity.status(HttpStatus.NO_CONTENT).build() }
 
 }

--- a/goms-presentation/src/main/kotlin/com/goms/v2/domain/account/dto/request/UpdatePasswordRequest.kt
+++ b/goms-presentation/src/main/kotlin/com/goms/v2/domain/account/dto/request/UpdatePasswordRequest.kt
@@ -1,0 +1,6 @@
+package com.goms.v2.domain.account.dto.request
+
+data class UpdatePasswordRequest(
+    val email: String,
+    val newPassword: String
+)

--- a/goms-presentation/src/main/kotlin/com/goms/v2/domain/account/mapper/AccountDataMapper.kt
+++ b/goms-presentation/src/main/kotlin/com/goms/v2/domain/account/mapper/AccountDataMapper.kt
@@ -1,6 +1,8 @@
 package com.goms.v2.domain.account.mapper
 
+import com.goms.v2.domain.account.data.dto.PasswordDto
 import com.goms.v2.domain.account.data.dto.ProfileDto
+import com.goms.v2.domain.account.dto.request.UpdatePasswordRequest
 import com.goms.v2.domain.account.dto.response.ProfileHttpResponse
 import org.springframework.stereotype.Component
 
@@ -18,6 +20,12 @@ class AccountDataMapper {
             lateCount = profileDto.lateCount,
             isOuting = profileDto.isOuting,
             isBlackList = profileDto.isBlackList
+        )
+
+    fun toDomain(updatePasswordRequest: UpdatePasswordRequest) =
+        PasswordDto(
+            email = updatePasswordRequest.email,
+            newPassword = updatePasswordRequest.newPassword
         )
 
 }

--- a/goms-presentation/src/test/kotlin/com/goms/v2/domain/account/AccountControllerTest.kt
+++ b/goms-presentation/src/test/kotlin/com/goms/v2/domain/account/AccountControllerTest.kt
@@ -1,18 +1,23 @@
 package com.goms.v2.domain.account
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.goms.v2.domain.account.constant.Authority
 import com.goms.v2.domain.account.constant.Gender
 import com.goms.v2.domain.account.constant.Major
+import com.goms.v2.domain.account.data.dto.PasswordDto
 import com.goms.v2.domain.account.data.dto.ProfileDto
+import com.goms.v2.domain.account.dto.request.UpdatePasswordRequest
 import com.goms.v2.domain.account.dto.response.ProfileHttpResponse
 import com.goms.v2.domain.account.mapper.AccountDataMapper
 import com.goms.v2.domain.account.usecase.QueryAccountProfileUseCase
+import com.goms.v2.domain.account.usecase.UpdatePasswordUseCase
 import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.every
 import io.mockk.mockk
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -23,9 +28,11 @@ class AccountControllerTest: DescribeSpec({
     lateinit var mockMvc: MockMvc
     val accountDataMapper = mockk<AccountDataMapper>()
     val queryAccountProfileUseCase = mockk<QueryAccountProfileUseCase>()
+    val updatePasswordUseCase = mockk<UpdatePasswordUseCase>()
     val accountController = AccountController(
         accountDataMapper,
-        queryAccountProfileUseCase
+        queryAccountProfileUseCase,
+        updatePasswordUseCase
     )
 
     beforeTest {
@@ -69,7 +76,7 @@ class AccountControllerTest: DescribeSpec({
                     .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
                     .andExpect(jsonPath("$.name").value(profileHttpResponse.name))
                     .andExpect(jsonPath("$.grade").value(profileHttpResponse.grade))
-                    .andExpect(jsonPath("$.gender").value(profileHttpResponse.gender))
+                    .andExpect(jsonPath("$.gender").value(profileHttpResponse.gender.toString()))
                     .andExpect(jsonPath("$.authority").value(profileHttpResponse.authority.toString()))
                     .andExpect(jsonPath("$.profileUrl").value(profileHttpResponse.profileUrl))
                     .andExpect(jsonPath("$.lateCount").value(profileHttpResponse.lateCount))
@@ -81,4 +88,33 @@ class AccountControllerTest: DescribeSpec({
 
     }
 
+
+    describe("api/v2/account/new-password patch 요청을 했을때") {
+        val url = "/api/v2/account/new-password"
+
+        val updatePasswordRequest = UpdatePasswordRequest(
+            email = "s22039@gsm.hs.kr",
+            newPassword = "gomstest1234!"
+        )
+        val passwordDto = PasswordDto(
+            email = "s22039@gsm.hs.kr",
+            newPassword = "gomstest1234!"
+        )
+
+        context("유효한 요청이 전달 되면") {
+
+            every { accountDataMapper.toDomain(updatePasswordRequest) } returns passwordDto
+            every { updatePasswordUseCase.execute(passwordDto) } returns Unit
+            val jsonRequestBody = jacksonObjectMapper().writeValueAsString(updatePasswordRequest)
+
+            it("204 status code를 응답해야한다.") {
+                mockMvc.perform(
+                    patch(url)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonRequestBody)
+                )
+                    .andExpect(status().`is`(204))
+            }
+        }
+    }
 })


### PR DESCRIPTION
## 💡 개요
+ 비밀번호 재설정 API 
## 📃 작업사항
+ entity에서 password를 지정할때 val에서 var로 변경하였습니다.
+ `UpdatePasswordRequest` dto를 `PasswordDto`로 타입을 변경하는 Mapper를 구현하였습니다.
+ 비밀번호 변경 UseCase를 구현하였습니다.
+ `AccountController`에 대한 api 테스트코드를 작성하였습니다.