### PR TITLE
🔀 :: 프로필 이미지 변경 api

### DIFF
--- a/goms-application/src/main/kotlin/com/goms/v2/domain/account/spi/S3UtillPort.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/account/spi/S3UtillPort.kt
@@ -1,7 +1,9 @@
 package com.goms.v2.domain.account.spi
 
+import com.goms.v2.domain.account.Account
 import org.springframework.web.multipart.MultipartFile
 
 interface S3UtilPort {
+    fun validImage(image: MultipartFile): Account
     fun upload(image: MultipartFile): String
 }

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/account/spi/S3UtillPort.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/account/spi/S3UtillPort.kt
@@ -6,4 +6,5 @@ import org.springframework.web.multipart.MultipartFile
 interface S3UtilPort {
     fun validImage(image: MultipartFile): Account
     fun upload(image: MultipartFile): String
+    fun deleteImage(url: String)
 }

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/account/usecase/UpdateImageUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/account/usecase/UpdateImageUseCase.kt
@@ -1,0 +1,25 @@
+package com.goms.v2.domain.account.usecase
+
+import com.goms.v2.common.annotation.UseCaseWithTransaction
+import com.goms.v2.domain.account.spi.S3UtilPort
+import com.goms.v2.domain.account.updateProfileUrl
+import com.goms.v2.repository.account.AccountRepository
+import org.springframework.web.multipart.MultipartFile
+
+@UseCaseWithTransaction
+class UpdateImageUseCase(
+        private val accountRepository: AccountRepository,
+        private val s3UtilPort: S3UtilPort,
+) {
+
+    fun execute(image: MultipartFile) {
+        val account = s3UtilPort.validImage(image)
+        s3UtilPort.deleteImage(account.profileUrl.toString())
+
+        val imgURL = s3UtilPort.upload(image)
+        account.updateProfileUrl(imgURL)
+        accountRepository.save(account)
+
+    }
+
+}

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/account/usecase/UploadImageUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/account/usecase/UploadImageUseCase.kt
@@ -13,23 +13,10 @@ import org.springframework.web.multipart.MultipartFile
 class UploadImageUseCase(
     private val accountRepository: AccountRepository,
     private val s3UtilPort: S3UtilPort,
-    private val accountUtil: AccountUtil
 ) {
 
     fun execute(image: MultipartFile) {
-        val accountIdx = accountUtil.getCurrentAccountIdx()
-        val account = accountRepository.findByIdOrNull(accountIdx) ?: throw AccountNotFoundException()
-
-        val list = listOf("jpg", "jpeg", "png", "gif")
-        val splitFile = image.originalFilename.toString().split(".")
-
-        if(splitFile.size < 2)
-            throw FileExtensionInvalidException()
-
-        val extension = splitFile[1].lowercase()
-
-        if(list.none { it == extension })
-            throw FileExtensionInvalidException()
+        val account = s3UtilPort.validImage(image)
 
         val imgURL = s3UtilPort.upload(image)
         account.updateProfileUrl(imgURL)

--- a/goms-application/src/test/kotlin/com/goms/v2/domain/account/UploadImageUseCaseTest.kt
+++ b/goms-application/src/test/kotlin/com/goms/v2/domain/account/UploadImageUseCaseTest.kt
@@ -18,8 +18,7 @@ import java.util.*
 class UploadImageUseCaseTest: BehaviorSpec({
     val accountRepository = mockk<AccountRepository>()
     val s3UtilPort = mockk<S3UtilPort>()
-    val accountUtil = mockk<AccountUtil>()
-    val uploadImageUseCase = UploadImageUseCase(accountRepository, s3UtilPort, accountUtil)
+    val uploadImageUseCase = UploadImageUseCase(accountRepository, s3UtilPort)
 
     Given("multipart image가 주어질 때") {
         val imageBytes = "image content".toByteArray(StandardCharsets.UTF_8)
@@ -29,9 +28,7 @@ class UploadImageUseCaseTest: BehaviorSpec({
         val accountIdx = UUID.randomUUID()
         val account = AnyValueObjectGenerator.anyValueObject<Account>("idx" to accountIdx)
 
-
-        every { accountUtil.getCurrentAccountIdx() } returns accountIdx
-        every { accountRepository.findByIdOrNull(accountIdx) } returns account
+        every { s3UtilPort.validImage(image) } returns account
         every { s3UtilPort.upload(image) } returns imageURL
         every { accountRepository.save(account) } returns account
 

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/thirdparty/aws/s3/S3UtilAdapter.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/thirdparty/aws/s3/S3UtilAdapter.kt
@@ -49,4 +49,8 @@ class S3UtilAdapter(
         return amazonS3.getUrl(bucket, profileName).toString()
     }
 
+    override fun deleteImage(url: String) {
+        val key = url.substringAfter("com/")
+        amazonS3.deleteObject(bucket, key)
+    }
 }

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/thirdparty/aws/s3/S3UtilAdapter.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/thirdparty/aws/s3/S3UtilAdapter.kt
@@ -2,7 +2,12 @@ package com.goms.v2.thirdparty.aws.s3
 
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.ObjectMetadata
+import com.goms.v2.common.util.AccountUtil
+import com.goms.v2.domain.account.Account
+import com.goms.v2.domain.account.exception.FileExtensionInvalidException
 import com.goms.v2.domain.account.spi.S3UtilPort
+import com.goms.v2.domain.auth.exception.AccountNotFoundException
+import com.goms.v2.repository.account.AccountRepository
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
@@ -10,13 +15,34 @@ import java.util.*
 
 @Component
 class S3UtilAdapter(
-        private val amazonS3: AmazonS3
+        private val amazonS3: AmazonS3,
+        private val accountUtil: AccountUtil,
+        private val accountRepository: AccountRepository
 ): S3UtilPort {
 
     @Value("\${cloud.aws.s3.bucket}")
     private val bucket: String? = null
-    override fun upload(file: MultipartFile): String {
-        val profileName = "${bucket}/${UUID.randomUUID()}${file.originalFilename}"
+
+    override fun validImage(image: MultipartFile): Account {
+        val accountIdx = accountUtil.getCurrentAccountIdx()
+        val account = accountRepository.findByIdOrNull(accountIdx) ?: throw AccountNotFoundException()
+
+        val list = listOf("jpg", "jpeg", "png", "gif")
+        val splitFile = image.originalFilename.toString().split(".")
+
+        if(splitFile.size < 2)
+            throw FileExtensionInvalidException()
+
+        val extension = splitFile[1].lowercase()
+
+        if(list.none { it == extension })
+            throw FileExtensionInvalidException()
+
+        return account;
+    }
+
+    override fun upload(image: MultipartFile): String {
+        val profileName = "${bucket}/${UUID.randomUUID()}${image.originalFilename}"
         val metadata = ObjectMetadata()
         metadata.contentLength = file.inputStream.available().toLong()
         amazonS3.putObject(bucket, profileName, file.inputStream, metadata)

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/thirdparty/aws/s3/S3UtilAdapter.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/thirdparty/aws/s3/S3UtilAdapter.kt
@@ -44,8 +44,8 @@ class S3UtilAdapter(
     override fun upload(image: MultipartFile): String {
         val profileName = "${bucket}/${UUID.randomUUID()}${image.originalFilename}"
         val metadata = ObjectMetadata()
-        metadata.contentLength = file.inputStream.available().toLong()
-        amazonS3.putObject(bucket, profileName, file.inputStream, metadata)
+        metadata.contentLength = image.inputStream.available().toLong()
+        amazonS3.putObject(bucket, profileName, image.inputStream, metadata)
         return amazonS3.getUrl(bucket, profileName).toString()
     }
 

--- a/goms-presentation/src/main/kotlin/com/goms/v2/domain/account/AccountController.kt
+++ b/goms-presentation/src/main/kotlin/com/goms/v2/domain/account/AccountController.kt
@@ -4,6 +4,7 @@ import com.goms.v2.domain.account.dto.request.UpdatePasswordRequest
 import com.goms.v2.domain.account.dto.response.ProfileHttpResponse
 import com.goms.v2.domain.account.mapper.AccountDataMapper
 import com.goms.v2.domain.account.usecase.QueryAccountProfileUseCase
+import com.goms.v2.domain.account.usecase.UpdateImageUseCase
 import com.goms.v2.domain.account.usecase.UpdatePasswordUseCase
 import com.goms.v2.domain.account.usecase.UploadImageUseCase
 import org.springframework.http.HttpStatus
@@ -24,7 +25,8 @@ class AccountController(
     private val accountDataMapper: AccountDataMapper,
     private val queryAccountProfileUseCase: QueryAccountProfileUseCase,
     private val updatePasswordUseCase: UpdatePasswordUseCase,
-    private val uploadImageUseCase: UploadImageUseCase
+    private val uploadImageUseCase: UploadImageUseCase,
+    private val updateImageUseCase: UpdateImageUseCase
 ) {
 
     @GetMapping("profile")
@@ -40,6 +42,11 @@ class AccountController(
     @PostMapping("image")
     fun uploadImage(@RequestPart("File") image: MultipartFile): ResponseEntity<Void> =
         uploadImageUseCase.execute(image)
+                .let { ResponseEntity.status(HttpStatus.RESET_CONTENT).build() }
+
+    @PatchMapping("image")
+    fun updateImage(@RequestPart("File") image: MultipartFile): ResponseEntity<Void> =
+        updateImageUseCase.execute(image)
                 .let { ResponseEntity.status(HttpStatus.RESET_CONTENT).build() }
 
 }

--- a/goms-presentation/src/test/kotlin/com/goms/v2/domain/account/AccountControllerTest.kt
+++ b/goms-presentation/src/test/kotlin/com/goms/v2/domain/account/AccountControllerTest.kt
@@ -10,6 +10,7 @@ import com.goms.v2.domain.account.dto.request.UpdatePasswordRequest
 import com.goms.v2.domain.account.dto.response.ProfileHttpResponse
 import com.goms.v2.domain.account.mapper.AccountDataMapper
 import com.goms.v2.domain.account.usecase.QueryAccountProfileUseCase
+import com.goms.v2.domain.account.usecase.UpdateImageUseCase
 import com.goms.v2.domain.account.usecase.UpdatePasswordUseCase
 import com.goms.v2.domain.account.usecase.UploadImageUseCase
 import io.kotest.core.spec.style.DescribeSpec
@@ -34,11 +35,13 @@ class AccountControllerTest: DescribeSpec({
     val queryAccountProfileUseCase = mockk<QueryAccountProfileUseCase>()
     val updatePasswordUseCase = mockk<UpdatePasswordUseCase>()
     val uploadImageUseCase = mockk<UploadImageUseCase>()
+    val updateImageUseCase = mockk<UpdateImageUseCase>()
     val accountController = AccountController(
         accountDataMapper,
         queryAccountProfileUseCase,
         updatePasswordUseCase,
-        uploadImageUseCase
+        uploadImageUseCase,
+        updateImageUseCase
     )
 
     beforeTest {


### PR DESCRIPTION
## 💡 개요
프로필 이미지를 있던 상태에서 변경할 수 있는 api를 만들었습니다.
## 📃 작업사항
* updateImageUseCase 추가
* s3UtilPort에 validImage, deleteImage 추가
* s3UtilAdapter에 validImage, deleteImage 로직 추가
* updateImageUseCase와 uploadImageUseCase에 중복되는 코드를 s3Util에 메서드 추가하여 코드 정리
## 🙋‍♂️ 리뷰내용