### PR TITLE
 :: 비밀번호 재설정 api 권한 변경

### DIFF
--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/global/security/config/SecurityConfig.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/global/security/config/SecurityConfig.kt
@@ -45,7 +45,7 @@ class SecurityConfig(
             // /account
             .mvcMatchers(HttpMethod.GET, "/api/v2/account/profile").hasAnyAuthority(Authority.ROLE_STUDENT.name, Authority.ROLE_STUDENT_COUNCIL.name)
             .mvcMatchers(HttpMethod.POST, "/api/v2/account/image").hasAnyAuthority(Authority.ROLE_STUDENT.name, Authority.ROLE_STUDENT_COUNCIL.name)
-            .mvcMatchers(HttpMethod.PATCH, "/api/v2/account/new-password").hasAnyAuthority(Authority.ROLE_STUDENT.name, Authority.ROLE_STUDENT_COUNCIL.name)
+            .mvcMatchers(HttpMethod.PATCH, "/api/v2/account/new-password").permitAll()
 
             // /outing
             .mvcMatchers(HttpMethod.POST, "/api/v2/outing/{outingUUID}").hasAnyAuthority(Authority.ROLE_STUDENT.name)


### PR DESCRIPTION
## 💡 개요
+ 비밀번호 재설정 api 접근 궈한 변경
+ 로그인 과정에서 비밀번호를 재설정 할 수 있으므로 토큰 없이도 api를 호출할 수 있어야합니다.
## 📃 작업사항
+ api에 대한 접근 권한을 hasAnyAuthority에서 permitAll로 변경하였습니다.
## 🙋‍♂️ 리뷰내용