### PR TITLE
#250 with draw delete info

### DIFF
--- a/goms-application/src/main/kotlin/com/goms/v2/domain/auth/usecase/WithdrawUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/auth/usecase/WithdrawUseCase.kt
@@ -2,15 +2,18 @@ package com.goms.v2.domain.auth.usecase
 
 import com.goms.v2.common.annotation.UseCaseWithTransaction
 import com.goms.v2.common.util.AccountUtil
-import com.goms.v2.domain.auth.data.dto.WithdrawDto
 import com.goms.v2.domain.auth.exception.AccountNotFoundException
 import com.goms.v2.domain.auth.exception.PasswordNotMatchException
 import com.goms.v2.domain.auth.spi.PasswordEncoderPort
 import com.goms.v2.repository.account.AccountRepository
+import com.goms.v2.repository.late.LateRepository
+import com.goms.v2.repository.outing.OutingRepository
 
 @UseCaseWithTransaction
 class WithdrawUseCase(
     private val accountRepository: AccountRepository,
+    private val lateRepository: LateRepository,
+    private val outingRepository: OutingRepository,
     private val accountUtil: AccountUtil,
     private val passwordEncoderPort: PasswordEncoderPort
 ) {
@@ -24,6 +27,8 @@ class WithdrawUseCase(
             throw PasswordNotMatchException()
         }
 
+        lateRepository.deleteAllByAccountIdx(accountIdx)
+        outingRepository.deleteAllByAccountIdx(accountIdx)
         accountRepository.delete(account)
     }
 

--- a/goms-domain/src/main/kotlin/com/goms/v2/repository/late/LateRepository.kt
+++ b/goms-domain/src/main/kotlin/com/goms/v2/repository/late/LateRepository.kt
@@ -11,5 +11,6 @@ interface LateRepository {
     fun findTop3ByOrderByAccountDesc(): List<Late>
     fun countByOneWeekAgoLate(oneWeekAgo: LocalDate): Long
     fun findAllByCreatedTime(date: LocalDate): List<Late>
+    fun deleteAllByAccountIdx(accountIdx: UUID)
 
 }

--- a/goms-domain/src/main/kotlin/com/goms/v2/repository/outing/OutingRepository.kt
+++ b/goms-domain/src/main/kotlin/com/goms/v2/repository/outing/OutingRepository.kt
@@ -8,6 +8,7 @@ interface OutingRepository {
 
     fun save(outing: Outing)
     fun deleteByAccountIdx(accountIdx: UUID)
+    fun deleteAllByAccountIdx(accountIdx: UUID)
     fun existsByAccount(account: Account): Boolean
     fun findAllByOrderByCreatedTimeDesc(): List<Outing>
     fun count(): Long

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/late/repository/LateJpaRepository.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/late/repository/LateJpaRepository.kt
@@ -1,6 +1,5 @@
 package com.goms.v2.persistence.late.repository
 
-import com.goms.v2.domain.late.Late
 import com.goms.v2.persistence.late.entity.LateJpaEntity
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
@@ -13,4 +12,5 @@ interface LateJpaRepository: CrudRepository<LateJpaEntity, UUID> {
     @Query("select count(*) from late l where l.createdTime = :oneWeekAgo")
     fun countByOneWeekAgoLate(oneWeekAgo: LocalDate): Long
     fun findAllByCreatedTime(date: LocalDate): List<LateJpaEntity>
+    fun deleteAllByAccountIdx(accountIdx: UUID)
 }

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/late/repository/LateRepositoryImpl.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/late/repository/LateRepositoryImpl.kt
@@ -62,4 +62,8 @@ class LateRepositoryImpl(
         lateJpaRepository.findAllByCreatedTime(date)
             .map { lateMapper.toDomain(it)!! }
 
+    override fun deleteAllByAccountIdx(accountIdx: UUID) {
+        lateJpaRepository.deleteAllByAccountIdx(accountIdx)
+    }
+
 }

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/outing/repository/OutingJpaRepository.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/outing/repository/OutingJpaRepository.kt
@@ -8,6 +8,7 @@ import java.util.UUID
 interface OutingJpaRepository: CrudRepository<OutingJpaEntity, Long> {
 
     fun deleteByAccountIdx(accountIdx: UUID)
+    fun deleteAllByAccountIdx(accountIdx: UUID)
     fun existsByAccount(account: AccountJpaEntity): Boolean
 
 }

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/outing/repository/OutingRepositoryImpl.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/outing/repository/OutingRepositoryImpl.kt
@@ -29,6 +29,10 @@ class OutingRepositoryImpl(
         outingJpaRepository.deleteByAccountIdx(accountIdx)
     }
 
+    override fun deleteAllByAccountIdx(accountIdx: UUID) {
+        outingJpaRepository.deleteAllByAccountIdx(accountIdx)
+    }
+
     override fun existsByAccount(account: Account): Boolean {
         val accountEntity = accountMapper.toEntity(account)
         return outingJpaRepository.existsByAccount(accountEntity)


### PR DESCRIPTION
## 💡 개요
+ 회원탈퇴 할때 유저의 지각정보, 외출정보 삭제
## 📃 작업사항
+ 회원탈퇴 로직에서 유저의 지각정보와 외출정보를 함께 삭제하도록 하였습니다.
