### PR TITLE
🔀 :: authentication expiredAt value

### DIFF
--- a/goms-domain/src/main/kotlin/com/goms/v2/domain/auth/Authentication.kt
+++ b/goms-domain/src/main/kotlin/com/goms/v2/domain/auth/Authentication.kt
@@ -12,7 +12,7 @@ data class Authentication(
 ) {
 
     companion object {
-        const val EXPIRED_AT = 7200L
+        const val EXPIRED_AT = 300L
     }
 
     fun certified() =


### PR DESCRIPTION
## 💡 개요
+ 이메일 인증 권한 시간 수정
## 📃 작업사항
+ 이메일 인증을 하면서 필요한 authentication에 유효기간을 1시간에서 5분으로 수정하였습니다.
+ 이 작업을 통해 이메일 전송 횟수가 5번이 넘었을때 대기시간을 5분으로 설정할 수 있습니다.
