### PR TITLE
#262 profile cache

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,6 +3,7 @@ object Dependencies {
     const val KOTLIN_REFLECT = "org.jetbrains.kotlin:kotlin-reflect"
     const val KOTLIN_JDK = "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     const val JACKSON_MODULE = "com.fasterxml.jackson.module:jackson-module-kotlin"
+    const val JACKSON_CORE_MODULE = "com.fasterxml.jackson.core:jackson-annotations:${DependenciesVersions.JACKSON_CORE}"
 
     /* java servlet */
     const val JAVA_SERVLET = "javax.servlet:javax.servlet-api:${DependenciesVersions.SERVLET_VERSION}"

--- a/buildSrc/src/main/kotlin/DependenciesVersions.kt
+++ b/buildSrc/src/main/kotlin/DependenciesVersions.kt
@@ -5,6 +5,7 @@ object DependenciesVersions {
     const val KOTEST_EXTENSION = "1.1.2"
     const val KOTEST_ASSERTIONS = "5.5.5"
     const val SPRING_TRANSACTION = "5.3.11"
+    const val JACKSON_CORE = "2.13.4"
     const val SPRING_TEST = "2.7.7"
     const val SERVLET_VERSION = "4.0.1"
     const val EMAIL = "2.6.7"

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/account/data/dto/ProfileDto.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/account/data/dto/ProfileDto.kt
@@ -12,6 +12,20 @@ data class ProfileDto(
     val authority: Authority,
     val profileUrl: String?,
     val lateCount: Long,
-    val isOuting: Boolean,
-    val isBlackList: Boolean
-)
+    val outing: Boolean,
+    val blackList: Boolean
+) {
+
+    constructor(): this(
+        "",
+        6,
+        Major.SMART_IOT,
+        Gender.MAN,
+        Authority.ROLE_STUDENT_COUNCIL,
+        null,
+        0L,
+        false,
+        false
+    )
+
+}

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/account/usecase/UpdateImageUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/account/usecase/UpdateImageUseCase.kt
@@ -1,17 +1,25 @@
 package com.goms.v2.domain.account.usecase
 
 import com.goms.v2.common.annotation.UseCaseWithTransaction
+import com.goms.v2.common.util.AccountUtil
 import com.goms.v2.domain.account.spi.S3UtilPort
 import com.goms.v2.domain.account.updateProfileUrl
 import com.goms.v2.repository.account.AccountRepository
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.web.multipart.MultipartFile
 
 @UseCaseWithTransaction
 class UpdateImageUseCase(
-        private val accountRepository: AccountRepository,
-        private val s3UtilPort: S3UtilPort,
+    private val accountRepository: AccountRepository,
+    private val s3UtilPort: S3UtilPort,
+    private val accountUtil: AccountUtil
 ) {
 
+    @CacheEvict(
+        value = ["userProfiles"],
+        key = "#root.target.generateCacheKey()",
+        cacheManager = "contentCacheManager"
+    )
     fun execute(image: MultipartFile) {
         val account = s3UtilPort.validImage(image)
         s3UtilPort.deleteImage(account.profileUrl.toString())
@@ -21,5 +29,9 @@ class UpdateImageUseCase(
         accountRepository.save(account)
 
     }
+
+    fun generateCacheKey(): String =
+        accountUtil.getCurrentAccountIdx().toString()
+
 
 }

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/outing/repository/OutingRepositoryImpl.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/outing/repository/OutingRepositoryImpl.kt
@@ -43,7 +43,7 @@ class OutingRepositoryImpl(
             .leftJoin(outingJpaEntity.account, accountJpaEntity).fetchJoin()
             .orderBy(outingJpaEntity.createdTime.desc())
             .fetch()
-            .map { outingMapper.toDomain(it)!! }
+            .map { outingMapper.toDomain(it) }
 
     override fun count(): Long =
         outingJpaRepository.count()

--- a/goms-presentation/build.gradle.kts
+++ b/goms-presentation/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
 
     /* kotlin */
     implementation(Dependencies.JACKSON_MODULE)
+    implementation(Dependencies.JACKSON_CORE_MODULE)
 
     /* validation */
     implementation(Dependencies.VALIDATION)

--- a/goms-presentation/src/main/kotlin/com/goms/v2/domain/account/mapper/AccountDataMapper.kt
+++ b/goms-presentation/src/main/kotlin/com/goms/v2/domain/account/mapper/AccountDataMapper.kt
@@ -22,8 +22,8 @@ class AccountDataMapper {
             authority = profileDto.authority,
             profileUrl = profileDto.profileUrl,
             lateCount = profileDto.lateCount,
-            isOuting = profileDto.isOuting,
-            isBlackList = profileDto.isBlackList
+            isOuting = profileDto.outing,
+            isBlackList = profileDto.blackList
         )
 
     fun toDomain(updatePasswordRequest: UpdatePasswordRequest) =

--- a/goms-presentation/src/test/kotlin/com/goms/v2/domain/account/AccountControllerTest.kt
+++ b/goms-presentation/src/test/kotlin/com/goms/v2/domain/account/AccountControllerTest.kt
@@ -62,8 +62,8 @@ class AccountControllerTest: DescribeSpec({
             authority = Authority.ROLE_STUDENT,
             profileUrl = null,
             lateCount = 0,
-            isOuting = false,
-            isBlackList = false
+            outing = false,
+            blackList = false
         )
         val profileHttpResponse = ProfileHttpResponse(
             name = "김경수",


### PR DESCRIPTION
## 💡 개요
+ 프로필 조회 API에 캐싱기능을 추가하였습니다.
## 📃 작업사항
+ 프로필을 조회하면 캐시에 조회된 데이터를 저장하도록 하였습니다.
+ 프로필 이미지를 수정하면 캐시에 데이터가 삭제되도록 하였습니다. (프로필 이미지 수정후 프로필을 다시 조회하면 그때 다시 수정된 프로필이 캐시에 저장되도록 구현)
## 🙋‍♂️ 리뷰내용
+ d3216f4b1d244730aec3868d0ae82d99bdd0ffb7 
현재 이와같이 기존의 `isOuting`, `isBlackList`를 `outing`, `blackList`로 바꾼 이유는 redis에서 값을 저장할때 `is` keyword 저장을 지원해주지 않기 때문에 캐시를 저장할때 자동으로 is를 생략하고 outing만 저장합니다.
그래서 저장된 캐시를 불러올때 에러가 발생해서 일단은 `outing`으로 변수명을 변경하였습니다. 추후에 `is` keyword로 변수명을 수정하고 다른 방법으로 리펙토링 하겠습니다. 참고해주세요 !