### PR TITLE
# 280 feat/outing profile cache delete

### DIFF
--- a/goms-application/src/main/kotlin/com/goms/v2/domain/studentCouncil/usecase/DeleteOutingUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/studentCouncil/usecase/DeleteOutingUseCase.kt
@@ -1,17 +1,25 @@
 package com.goms.v2.domain.studentCouncil.usecase
 
 import com.goms.v2.common.annotation.UseCaseWithTransaction
+import com.goms.v2.common.util.AccountUtil
 import com.goms.v2.domain.auth.exception.AccountNotFoundException
 import com.goms.v2.repository.account.AccountRepository
 import com.goms.v2.repository.outing.OutingRepository
+import org.springframework.cache.annotation.CacheEvict
 import java.util.*
 
 @UseCaseWithTransaction
 class DeleteOutingUseCase(
     private val accountRepository: AccountRepository,
-    private val outingRepository: OutingRepository
+    private val outingRepository: OutingRepository,
+    private val accountUtil: AccountUtil
 ) {
 
+    @CacheEvict(
+        value = ["userProfiles"],
+        key = "#accountIdx",
+        cacheManager = "contentCacheManager"
+    )
     fun execute(accountIdx: UUID) {
         val account = accountRepository.findByIdOrNull(accountIdx) ?: throw AccountNotFoundException()
         outingRepository.deleteByAccountIdx(account.idx)

--- a/goms-application/src/test/kotlin/com/goms/v2/domain/studentCouncil/DeleteOutingUseCaseTest.kt
+++ b/goms-application/src/test/kotlin/com/goms/v2/domain/studentCouncil/DeleteOutingUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.goms.v2.domain.studentCouncil
 
 import com.goms.v2.common.AnyValueObjectGenerator
+import com.goms.v2.common.util.AccountUtil
 import com.goms.v2.domain.account.Account
 import com.goms.v2.domain.auth.exception.AccountNotFoundException
 import com.goms.v2.domain.studentCouncil.usecase.DeleteOutingUseCase
@@ -17,7 +18,8 @@ class DeleteOutingUseCaseTest : BehaviorSpec({
 
     val accountRepository = mockk<AccountRepository>()
     val outingRepository = mockk<OutingRepository>()
-    val deleteOutingUseCase = DeleteOutingUseCase(accountRepository, outingRepository)
+    val accountUtil = mockk<AccountUtil>()
+    val deleteOutingUseCase = DeleteOutingUseCase(accountRepository, outingRepository, accountUtil)
 
     Given("accountIdx가 주어졌을때") {
         val accountIdx = UUID.randomUUID()


### PR DESCRIPTION
## 💡 개요
+ 학생회가 외출자를 외출자 명단에서 삭제시키면 외출상태가 `외출중` 에서 `외출 대기중` 으로 상태가 변경되어야 합니다.
+ 외출자 명단에서 삭제할때 학생 정보에 대한 캐시를 삭제하지 않으면 복귀를 해도 `외출중`이라는 상태를 캐시에서 불러옵니다.
## 📃 작업사항
+ 사용자 프로필에 대한 캐시 데이터가 업데이트 될 수 있도록 외출 상태가 변경되면 프로필 캐시를 삭제하도록 하였습니다.
## 🙋‍♂️ 리뷰내용