### PR TITLE
#283 feat/user profile cache delete

### DIFF
--- a/goms-application/src/main/kotlin/com/goms/v2/domain/studentCouncil/usecase/GrantAuthorityUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/studentCouncil/usecase/GrantAuthorityUseCase.kt
@@ -5,12 +5,18 @@ import com.goms.v2.domain.account.updateAuthority
 import com.goms.v2.domain.auth.exception.AccountNotFoundException
 import com.goms.v2.domain.studentCouncil.data.dto.GrantAuthorityDto
 import com.goms.v2.repository.account.AccountRepository
+import org.springframework.cache.annotation.CacheEvict
 
 @UseCaseWithTransaction
 class GrantAuthorityUseCase(
     private val accountRepository: AccountRepository
 ) {
 
+    @CacheEvict(
+        value = ["userProfiles"],
+        key = "#dto.accountIdx",
+        cacheManager = "contentCacheManager"
+    )
     fun execute(dto: GrantAuthorityDto) {
         val account = accountRepository.findByIdOrNull(dto.accountIdx)
             ?: throw AccountNotFoundException()


### PR DESCRIPTION
## 💡 개요
+ 학생회가 사용자의 권한을 변경하면 학생의 권한이 변경되어야 합니다.
+ 프로필에서 권한이 변경될때 학생 정보에 대한 캐시를 삭제하지 않으면 권한이 바뀌어도 이전 권한 페이지가 보입니다.
## 📃 작업사항
+ 사용자 프로필에 대한 캐시 데이터가 업데이트 될 수 있도록 학생의 권한이 변경되면 프로필 캐시를 삭제하도록 하였습니다.
## 🙋‍♂️ 리뷰내용