### PR TITLE
🔀 :: 개인 프로필 정보를 캐시에 저장하는 기능을 제거하였습ㄴ디ㅏ.

### DIFF
--- a/goms-application/src/main/kotlin/com/goms/v2/domain/account/usecase/DeleteImageUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/account/usecase/DeleteImageUseCase.kt
@@ -7,7 +7,6 @@ import com.goms.v2.domain.account.resetProfileUrl
 import com.goms.v2.domain.account.spi.S3UtilPort
 import com.goms.v2.domain.auth.exception.AccountNotFoundException
 import com.goms.v2.repository.account.AccountRepository
-import org.springframework.cache.annotation.CacheEvict
 
 @UseCaseWithTransaction
 class DeleteImageUseCase(
@@ -16,11 +15,6 @@ class DeleteImageUseCase(
     private val accountUtil: AccountUtil
 ) {
 
-    @CacheEvict(
-        value = ["userProfiles"],
-        key = "#root.target.generateCacheKey()",
-        cacheManager = "contentCacheManager"
-    )
     fun execute() {
         val accountIdx = accountUtil.getCurrentAccountIdx()
         val account = accountRepository.findByIdOrNull(accountIdx) ?: throw AccountNotFoundException()
@@ -32,9 +26,5 @@ class DeleteImageUseCase(
 
         accountRepository.save(account)
     }
-
-    fun generateCacheKey(): String =
-        accountUtil.getCurrentAccountIdx().toString()
-
 
 }

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/account/usecase/QueryAccountProfileUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/account/usecase/QueryAccountProfileUseCase.kt
@@ -8,7 +8,6 @@ import com.goms.v2.repository.account.AccountRepository
 import com.goms.v2.repository.late.LateRepository
 import com.goms.v2.repository.outing.OutingBlackListRepository
 import com.goms.v2.repository.outing.OutingRepository
-import org.springframework.cache.annotation.Cacheable
 
 @UseCaseWithTransaction
 class QueryAccountProfileUseCase(
@@ -19,11 +18,6 @@ class QueryAccountProfileUseCase(
     private val outingBlackListRepository: OutingBlackListRepository
 ) {
 
-    @Cacheable(
-        value = ["userProfiles"],
-        key = "#root.target.generateCacheKey()",
-        cacheManager = "contentCacheManager"
-    )
     fun execute(): ProfileDto {
         val accountIdx = accountUtil.getCurrentAccountIdx()
         val account = accountRepository.findByIdOrNull(accountIdx) ?: throw AccountNotFoundException()
@@ -41,8 +35,5 @@ class QueryAccountProfileUseCase(
             blackList = outingBlackListRepository.existsById(account.idx)
         )
     }
-
-    fun generateCacheKey(): String =
-        accountUtil.getCurrentAccountIdx().toString()
 
 }

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/account/usecase/UpdateImageUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/account/usecase/UpdateImageUseCase.kt
@@ -1,25 +1,17 @@
 package com.goms.v2.domain.account.usecase
 
 import com.goms.v2.common.annotation.UseCaseWithTransaction
-import com.goms.v2.common.util.AccountUtil
 import com.goms.v2.domain.account.spi.S3UtilPort
 import com.goms.v2.domain.account.updateProfileUrl
 import com.goms.v2.repository.account.AccountRepository
-import org.springframework.cache.annotation.CacheEvict
 import org.springframework.web.multipart.MultipartFile
 
 @UseCaseWithTransaction
 class UpdateImageUseCase(
     private val accountRepository: AccountRepository,
     private val s3UtilPort: S3UtilPort,
-    private val accountUtil: AccountUtil
 ) {
 
-    @CacheEvict(
-        value = ["userProfiles"],
-        key = "#root.target.generateCacheKey()",
-        cacheManager = "contentCacheManager"
-    )
     fun execute(image: MultipartFile) {
         val account = s3UtilPort.validImage(image)
         s3UtilPort.deleteImage(account.profileUrl.toString())
@@ -29,9 +21,5 @@ class UpdateImageUseCase(
         accountRepository.save(account)
 
     }
-
-    fun generateCacheKey(): String =
-        accountUtil.getCurrentAccountIdx().toString()
-
 
 }

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/outing/usecase/OutingUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/outing/usecase/OutingUseCase.kt
@@ -10,7 +10,6 @@ import com.goms.v2.repository.account.AccountRepository
 import com.goms.v2.repository.outing.OutingBlackListRepository
 import com.goms.v2.repository.outing.OutingRepository
 import com.goms.v2.repository.studentCouncil.OutingUUIDRepository
-import org.springframework.cache.annotation.CacheEvict
 import java.time.LocalTime
 import java.util.UUID
 
@@ -23,11 +22,6 @@ class OutingUseCase(
     private val accountUtil: AccountUtil
 ) {
 
-    @CacheEvict(
-        value = ["userProfiles"],
-        key = "#root.target.generateCacheKey()",
-        cacheManager = "contentCacheManager"
-    )
     fun execute(outingUUID: UUID) {
         val accountIdx = accountUtil.getCurrentAccountIdx()
         val account = accountRepository.findByIdOrNull(accountIdx) ?: throw AccountNotFoundException()
@@ -48,9 +42,5 @@ class OutingUseCase(
             true -> outingRepository.deleteByAccountIdx(account.idx)
         }
     }
-
-    fun generateCacheKey(): String =
-        accountUtil.getCurrentAccountIdx().toString()
-
 
 }

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/studentCouncil/usecase/DeleteOutingUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/studentCouncil/usecase/DeleteOutingUseCase.kt
@@ -5,21 +5,14 @@ import com.goms.v2.common.util.AccountUtil
 import com.goms.v2.domain.auth.exception.AccountNotFoundException
 import com.goms.v2.repository.account.AccountRepository
 import com.goms.v2.repository.outing.OutingRepository
-import org.springframework.cache.annotation.CacheEvict
 import java.util.*
 
 @UseCaseWithTransaction
 class DeleteOutingUseCase(
     private val accountRepository: AccountRepository,
     private val outingRepository: OutingRepository,
-    private val accountUtil: AccountUtil
 ) {
 
-    @CacheEvict(
-        value = ["userProfiles"],
-        key = "#accountIdx",
-        cacheManager = "contentCacheManager"
-    )
     fun execute(accountIdx: UUID) {
         val account = accountRepository.findByIdOrNull(accountIdx) ?: throw AccountNotFoundException()
         outingRepository.deleteByAccountIdx(account.idx)

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/studentCouncil/usecase/GrantAuthorityUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/studentCouncil/usecase/GrantAuthorityUseCase.kt
@@ -5,18 +5,12 @@ import com.goms.v2.domain.account.updateAuthority
 import com.goms.v2.domain.auth.exception.AccountNotFoundException
 import com.goms.v2.domain.studentCouncil.data.dto.GrantAuthorityDto
 import com.goms.v2.repository.account.AccountRepository
-import org.springframework.cache.annotation.CacheEvict
 
 @UseCaseWithTransaction
 class GrantAuthorityUseCase(
     private val accountRepository: AccountRepository
 ) {
 
-    @CacheEvict(
-        value = ["userProfiles"],
-        key = "#dto.accountIdx",
-        cacheManager = "contentCacheManager"
-    )
     fun execute(dto: GrantAuthorityDto) {
         val account = accountRepository.findByIdOrNull(dto.accountIdx)
             ?: throw AccountNotFoundException()

--- a/goms-application/src/test/kotlin/com/goms/v2/domain/studentCouncil/DeleteOutingUseCaseTest.kt
+++ b/goms-application/src/test/kotlin/com/goms/v2/domain/studentCouncil/DeleteOutingUseCaseTest.kt
@@ -18,8 +18,7 @@ class DeleteOutingUseCaseTest : BehaviorSpec({
 
     val accountRepository = mockk<AccountRepository>()
     val outingRepository = mockk<OutingRepository>()
-    val accountUtil = mockk<AccountUtil>()
-    val deleteOutingUseCase = DeleteOutingUseCase(accountRepository, outingRepository, accountUtil)
+    val deleteOutingUseCase = DeleteOutingUseCase(accountRepository, outingRepository)
 
     Given("accountIdx가 주어졌을때") {
         val accountIdx = UUID.randomUUID()


### PR DESCRIPTION
## 💡 개요
+ 학생 프로필을 저장하는 캐시를 삭제하였습니다.
## 📃 작업사항
+ 프로필을 조회하면 캐시에 저장해놓고 캐시에서 데이터를 가져오도록 구현했는데, 학생 프로필 특성상 변경사항이 많아서(외출/복귀, 프로필 사진 변경, 권한 변경 등) 캐시에 저장 안하기로 결정하였습니다.
## 🙋‍♂️ 리뷰내용