### PR TITLE
🔀 :: notification port, mail send adapter ocp 적용

### DIFF
--- a/goms-application/src/main/kotlin/com/goms/v2/domain/auth/spi/EmailSendPort.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/auth/spi/EmailSendPort.kt
@@ -1,7 +1,0 @@
-package com.goms.v2.domain.auth.spi
-
-interface EmailSendPort {
-
-    fun sendEmail(email: String, authCode: String)
-
-}

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/auth/spi/NotificationSendPort.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/auth/spi/NotificationSendPort.kt
@@ -1,0 +1,7 @@
+package com.goms.v2.domain.auth.spi
+
+interface NotificationSendPort {
+
+    fun sendNotification(email: String, authCode: String)
+
+}

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/auth/usecase/SendAuthCodeUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/auth/usecase/SendAuthCodeUseCase.kt
@@ -6,7 +6,7 @@ import com.goms.v2.domain.auth.Authentication
 import com.goms.v2.domain.auth.data.dto.SendAuthCodeDto
 import com.goms.v2.domain.auth.data.event.CreateAuthenticationEvent
 import com.goms.v2.domain.auth.exception.ManyEmailRequestException
-import com.goms.v2.domain.auth.spi.EmailSendPort
+import com.goms.v2.domain.auth.spi.NotificationSendPort
 import com.goms.v2.repository.auth.AuthCodeRepository
 import com.goms.v2.repository.auth.AuthenticationRepository
 import org.springframework.context.ApplicationEventPublisher
@@ -14,7 +14,7 @@ import java.util.*
 
 @UseCaseWithTransaction
 class SendAuthCodeUseCase(
-    private val emailSendPort: EmailSendPort,
+    private val notificationSendPort: NotificationSendPort,
     private val authenticationRepository: AuthenticationRepository,
     private val authCodeRepository: AuthCodeRepository,
     private val publisher: ApplicationEventPublisher
@@ -33,7 +33,7 @@ class SendAuthCodeUseCase(
         }
 
         val code = createCode()
-        emailSendPort.sendEmail(dto.email, code)
+        notificationSendPort.sendNotification(dto.email, code)
         val authCode = AuthCode(
             email = dto.email,
             authCode = code,

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/thirdparty/email/MailSendAdapter.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/thirdparty/email/MailSendAdapter.kt
@@ -1,7 +1,7 @@
 package com.goms.v2.thirdparty.email
 
 import com.goms.v2.domain.auth.exception.EmailSendFailException
-import com.goms.v2.domain.auth.spi.EmailSendPort
+import com.goms.v2.domain.auth.spi.NotificationSendPort
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.scheduling.annotation.Async
@@ -10,17 +10,17 @@ import org.thymeleaf.context.Context
 import org.thymeleaf.spring5.SpringTemplateEngine
 
 @Component
-class EmailSendAdapter(
+class MailSendAdapter(
     private val mailSender: JavaMailSender,
     private val templateEngine: SpringTemplateEngine
-): EmailSendPort {
+): NotificationSendPort {
 
     companion object {
         val EMAIL_SUBJECT = "GOMS 이메일 인증"
     }
 
     @Async
-    override fun sendEmail(email: String, authCode: String) {
+    override fun sendNotification(email: String, authCode: String) {
         val message = mailSender.createMimeMessage()
         val helper = MimeMessageHelper(message, "utf-8")
         helper.setTo(email)


### PR DESCRIPTION
## 💡 개요
+ 알림 전송 코드에 OCP를 적용시켰습니다.
## 📃 작업사항
+ `NotificationSendPort`이라는 추상화된 인터페이스를 만들었습니다.
+ `NotificationSendPort` 인터페이스를 구현하는 이메일 전송 클래스를 만들었습니다.
+ 추후에 알림 전송 기능으로 문자 전송 기능이 추가될때 기존의 코드를 변경하는 것이 아닌`NotificationSendPort` 인터페이스를 구현하는 또 다른 클래스 문자 전송 클래스를 만들어서 문자 전송 기능을 구현할 수 있도록 설계하였습니다.