### PR TITLE
🔄️ FCM 토큰 중복 저장 문제 수정

### DIFF
--- a/goms-application/src/main/kotlin/com/goms/v2/domain/notification/usecase/SendCustomNotificationUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/notification/usecase/SendCustomNotificationUseCase.kt
@@ -25,7 +25,9 @@ class SendCustomNotificationUseCase(
 
         runCatching {
             notificationPort.sendNotification(
-                deviceTokens = deviceTokenRepository.findAll().map { it.token },
+                deviceTokens = deviceTokenRepository.findAll()
+                    .map { it.token }
+                    .distinct(),
                 notificationConfig = NotificationConfig(
                     title = sendCustomNotificationDto.title,
                     content = sendCustomNotificationDto.content,

--- a/goms-application/src/main/kotlin/com/goms/v2/domain/notification/usecase/SendNotificationUseCase.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/notification/usecase/SendNotificationUseCase.kt
@@ -21,7 +21,10 @@ class SendNotificationUseCase(
             NotificationType.FIRST_NOTIFICATION -> {
                 runCatching {
                     notificationPort.sendNotification(
-                        deviceTokens = deviceTokenRepository.findAll().map { it.token },
+                        deviceTokens = deviceTokenRepository.findAll()
+                            .map { it.token }
+                            .distinct()
+                        ,
                         notificationConfig = NotificationConfig(
                                 title = if(isTodayDeniedOuting) Topic.DENIED_NOTIFICATION.title
                                     else Topic.FIRST_NOTIFICATION.title,
@@ -39,7 +42,9 @@ class SendNotificationUseCase(
                 if(!isTodayDeniedOuting){
                     runCatching {
                         notificationPort.sendNotification(
-                            deviceTokens = deviceTokenRepository.findAll().map { it.token },
+                            deviceTokens = deviceTokenRepository.findAll()
+                                .map { it.token }
+                                .distinct(),
                             notificationConfig = NotificationConfig(
                                 title = Topic.FINAL_NOTIFICATION.title,
                                 content = Topic.FINAL_NOTIFICATION.content,

--- a/goms-domain/src/main/kotlin/com/goms/v2/domain/notification/DeviceToken.kt
+++ b/goms-domain/src/main/kotlin/com/goms/v2/domain/notification/DeviceToken.kt
@@ -6,5 +6,5 @@ import java.util.UUID
 @RootAggregate
 data class DeviceToken(
     val accountIdx: UUID,
-    val token: String
+    val token: Set<String>
 )

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/notification/entity/DeviceTokenEntity.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/persistence/notification/entity/DeviceTokenEntity.kt
@@ -8,5 +8,5 @@ import java.util.*
 data class DeviceTokenEntity(
     @Id
     val accountIdx: UUID,
-    val token: String
+    val token: Set<String>
 )


### PR DESCRIPTION
## 💡 개요
동일한 FCM 토큰이 이미 존재해도 Redis 저장소에 또다시 저장하여 누적된 토큰 갯수만큼 푸시 알림을 전송하는 문제를 수정하였습니다
## 📃 작업사항
Redis Entity에서 토큰 필드를 ``Set<>``으로 바꾸었고 전송 로직에서도 중복 토큰값은 제거하도록 수정하여 푸시 알림이 여러번 가는 문제를 수정하였습니다
## 🙋‍♂️ 리뷰내용