### PR TITLE
🔄️ 무효한 스케쥴러 메서드 주석처리

### DIFF
--- a/goms-application/src/main/kotlin/com/goms/v2/domain/notification/scheduler/NotificationScheduler.kt
+++ b/goms-application/src/main/kotlin/com/goms/v2/domain/notification/scheduler/NotificationScheduler.kt
@@ -9,11 +9,11 @@ import org.springframework.stereotype.Component
 class NotificationScheduler(
     private val sendNotificationUseCase: SendNotificationUseCase
 ) {
-    @Scheduled(cron = "0 30 17 ? * 1,3") // 매주 월요일, 수요일 5시 30분에 미리 공지한다. (1시간 10분 전)
-    fun sendFirstNotification() =
-        sendNotificationUseCase.execute(NotificationType.FIRST_NOTIFICATION)
-
-    @Scheduled(cron = "0 35 18 ? * 1,3") // 매주 월요일, 수요일 6시 35분에 공지한다. (5분 전)
-    fun sendSecondNotification() =
-        sendNotificationUseCase.execute(NotificationType.FINAL_NOTIFICATION)
+//    @Scheduled(cron = "0 30 17 ? * 1,3") // 매주 월요일, 수요일 5시 30분에 미리 공지한다. (1시간 10분 전)
+//    fun sendFirstNotification() =
+//        sendNotificationUseCase.execute(NotificationType.FIRST_NOTIFICATION)
+//
+//    @Scheduled(cron = "0 35 18 ? * 1,3") // 매주 월요일, 수요일 6시 35분에 공지한다. (5분 전)
+//    fun sendSecondNotification() =
+//        sendNotificationUseCase.execute(NotificationType.FINAL_NOTIFICATION)
 }

--- a/goms-infrastructure/src/main/kotlin/com/goms/v2/global/log/LoggingScheduler.kt
+++ b/goms-infrastructure/src/main/kotlin/com/goms/v2/global/log/LoggingScheduler.kt
@@ -15,22 +15,21 @@ class LoggingScheduler(
     private val awsS3Properties: AwsS3Properties
 ) {
 
-    @Scheduled(cron = "0 3 * * * ?")
-    fun sendLog() {
-        val logDir = "./logs/"
-        val logDirectory = File(logDir)
-        logDirectory.listFiles()
-            .forEach { file ->
-                val fileName = file.name
-                val objectMetadata = ObjectMetadata()
-                objectMetadata.contentLength = file.length()
-                objectMetadata.contentType = "text/plain"
-                amazonS3.putObject(
-                    PutObjectRequest(awsS3Properties.bucketLog, fileName, file.inputStream(), objectMetadata)
-                        .withCannedAcl(CannedAccessControlList.PublicRead)
-                )
-                file.delete()
-            }
-    }
-
+//    @Scheduled(cron = "0 3 * * * ?")
+//    fun sendLog() {
+//        val logDir = "./logs/"
+//        val logDirectory = File(logDir)
+//        logDirectory.listFiles()
+//            .forEach { file ->
+//                val fileName = file.name
+//                val objectMetadata = ObjectMetadata()
+//                objectMetadata.contentLength = file.length()
+//                objectMetadata.contentType = "text/plain"
+//                amazonS3.putObject(
+//                    PutObjectRequest(awsS3Properties.bucketLog, fileName, file.inputStream(), objectMetadata)
+//                        .withCannedAcl(CannedAccessControlList.PublicRead)
+//                )
+//                file.delete()
+//            }
+//    }
 }


### PR DESCRIPTION
## 💡 개요
두 가지 다른 스케줄러 클래스에서 예약된 작업을 주석으로 남깁니다. 주요 효과는 특정 자동 알림 및 로그 업로드가 더 이상 예약된 크론 작업에 의해 트리거되지 않는다는 것입니다.
## 📃 작업사항
가장 중요한 변화는 다음과 같습니다:

**알림 일정:**:
* '알림 스케줄러'에서 '첫 번째 알림 보내기'와 '두 번째 알림 보내기'라는 예약된 메서드를 수정했는데, 이 메서드는 이전에 월요일과 수요일에 자동 알림을 보냈습니다.

**로그 업로드 일정:**:
* 'LoggingScheduler'의 예약된 메서드 'sendLog'에 대해 수정했습니다. 이 메서드는 이전에 매시간 로그 파일을 AWS S3에 업로드한 후 로컬에서 삭제했습니다.
## 🙋‍♂️ 리뷰내용
